### PR TITLE
Fixed description update when OU have child OU.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,10 @@ coverage.txt
 # ignore release build
 **/dist/*
 
+# goland idea files
+.idea/*
+
+
 _site
 .sass-cache
 .jekyll-metadata

--- a/activedirectory/computer_test.go
+++ b/activedirectory/computer_test.go
@@ -25,7 +25,7 @@ func createADComputerResult() *ldap.SearchResult {
 	return createADResult(1, attributes)
 }
 
-func TestGetComputer(t *testing.T) { // nolint:funlen
+func TestGetComputer(t *testing.T) { // nolint:funlen // Test function
 	name := getRandomString(10)
 	attributes := []string{"description", "cn"}
 

--- a/activedirectory/provider_test.go
+++ b/activedirectory/provider_test.go
@@ -11,10 +11,10 @@ import (
 )
 
 // acceptance tests
-var testAccProviders map[string]terraform.ResourceProvider // nolint:gochecknoglobals
-var testAccProvider *schema.Provider                       // nolint:gochecknoglobals
+var testAccProviders map[string]terraform.ResourceProvider // nolint:gochecknoglobals // Need it for Acc tests
+var testAccProvider *schema.Provider                       // nolint:gochecknoglobals // Need it for Acc tests
 
-func init() { // nolint:gochecknoinits
+func init() { // nolint:gochecknoinits // Used init function for some reason
 	testAccProvider = Provider().(*schema.Provider)
 	testAccProviders = map[string]terraform.ResourceProvider{
 		"activedirectory": testAccProvider,


### PR DESCRIPTION
Ldap search where base DN is OU and filter are set on any class, returning also all children of this OU

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/ParagonIaC/terraform-provider-activedirectory/blob/master/CHANGELOG.md):

(If change is not user facing, just write "NONE" in the release-note block below.)

```release-note

```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
